### PR TITLE
fixed the README.md because no link for #talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Micro Frontends are an _architectural pattern_, just as Microservices are. There
 - [Tooling](#tooling)
     - [Building Blocks](#building-blocks)
     - [Frameworks](#tooling)
-- [Talks](#talks)
 - [Meta](#meta)
     - [Other lists](#other-lists)
     - [Books](#books)


### PR DESCRIPTION
Hey @ChristianUlbrich .

The talks link in README.md was broken, so I updated it.
If you intentionally hold a broken link, please reject it.